### PR TITLE
URL query parameters are now included in the intent extras

### DIFF
--- a/RoutableTestTest/src/com/usepropeller/routable/test/RouterTest.java
+++ b/RoutableTestTest/src/com/usepropeller/routable/test/RouterTest.java
@@ -8,6 +8,7 @@ import junit.framework.Assert;
 
 import android.app.ListActivity;
 import android.content.Intent;
+import android.os.Bundle;
 import android.test.AndroidTestCase;
 
 public class RouterTest extends AndroidTestCase {
@@ -70,7 +71,7 @@ public class RouterTest extends AndroidTestCase {
 	}
 
 	public void test_code_callbacks() {
-		Router router = new Router();
+		Router router = new Router(this.getContext());
 		router.map("callback", new Router.RouterCallback() {
 			@Override
 			public void run(Map<String, String> params) {
@@ -84,7 +85,7 @@ public class RouterTest extends AndroidTestCase {
 	}
 
 	public void test_code_callbacks_with_params() {
-		Router router = new Router();
+		Router router = new Router(this.getContext());
 		router.map("callback/:id", new Router.RouterCallback() {
 			@Override
 			public void run(Map<String, String> params) {
@@ -104,6 +105,48 @@ public class RouterTest extends AndroidTestCase {
 
         Intent intent = router.intentFor("/users");
         Assert.assertNull(intent.getExtras());
+    }
+
+    public void test_url_querystring() {
+        Router router = new Router();
+        router.map("/users/:id", ListActivity.class);
+
+        Intent intent = router.intentFor("/users/123?key1=val2");
+        Bundle extras = intent.getExtras();
+
+        Assert.assertEquals("123", extras.getString("id"));
+        Assert.assertEquals("val2", extras.getString("key1"));
+    }
+
+    public void test_url_containing_spaces() {
+        Router router = new Router();
+        router.map("/path+entry/:id", ListActivity.class);
+
+        Intent intent = router.intentFor("/path+entry/123");
+        Bundle extras = intent.getExtras();
+
+        Assert.assertEquals("123", extras.getString("id"));
+    }
+
+    public void test_url_querystring_with_encoded_value() {
+        Router router = new Router();
+        router.map("/users/:id", ListActivity.class);
+
+        Intent intent = router.intentFor("/users/123?key1=val+1&key2=val%202");
+        Bundle extras = intent.getExtras();
+
+        Assert.assertEquals("val 1", extras.getString("key1"));
+        Assert.assertEquals("val 2", extras.getString("key2"));
+    }
+
+    public void test_url_querystring_without_value() {
+        Router router = new Router();
+        router.map("/users/:id", ListActivity.class);
+
+        Intent intent = router.intentFor("/users/123?val1");
+        Bundle extras = intent.getExtras();
+
+        Assert.assertTrue(extras.containsKey("val1"));
     }
 
     public void test_url_starting_with_slash_with_params() {

--- a/src/com/usepropeller/routable/Router.java
+++ b/src/com/usepropeller/routable/Router.java
@@ -26,7 +26,9 @@
 
 package com.usepropeller.routable;
 
+import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 
@@ -35,6 +37,9 @@ import android.content.Context;
 import android.content.Intent;
 import android.net.Uri;
 import android.os.Bundle;
+
+import org.apache.http.NameValuePair;
+import org.apache.http.client.utils.URLEncodedUtils;
 
 public class Router {
 	private static final Router _router = new Router();
@@ -361,11 +366,15 @@ public class Router {
 	private RouterParams paramsForUrl(String url) {
         final String cleanedUrl = cleanUrl(url);
 
-		if (this._cachedRoutes.get(url) != null) {
+		URI parsedUri = URI.create("http://tempuri.org/" + cleanedUrl);
+
+		String urlPath = parsedUri.getPath().substring(1);
+
+		if (this._cachedRoutes.get(cleanedUrl) != null) {
 			return this._cachedRoutes.get(cleanedUrl);
 		}
 
-		String[] givenParts = cleanedUrl.split("/");
+		String[] givenParts = urlPath.split("/");
 
 		RouterOptions openOptions = null;
 		RouterParams openParams = null;
@@ -392,6 +401,12 @@ public class Router {
 
 		if (openOptions == null || openParams == null) {
 			throw new RouteNotFoundException("No route found for url " + url);
+		}
+
+		List<NameValuePair> query = URLEncodedUtils.parse(parsedUri, "utf-8");
+
+		for (NameValuePair pair : query) {
+			openParams.openParams.put(pair.getName(), pair.getValue());
 		}
 
 		this._cachedRoutes.put(cleanedUrl, openParams);


### PR DESCRIPTION
Added support for parsing querystring parameters and supplying them as part of the params (to both the callback and intent). Resolves #10 